### PR TITLE
Link binaries according to settings in xcconfig instead

### DIFF
--- a/lib/cocoapods-spm/hooks/post_integrate/add_spm_pkgs.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/add_spm_pkgs.rb
@@ -37,11 +37,6 @@ module Pod
               pkg_ref = spm_pkg_refs[dep.pkg.name]
               target_dep_ref = pkg_ref.create_target_dependency_ref(dep.product)
               target.dependencies << target_dep_ref
-
-              # TODO: Don't add to `package_product_dependencies`.
-              # Otherwise, the product will be statically linked to the target.
-              # Let it be linked according to settings in `xcconfig` files.
-              target.package_product_dependencies << target_dep_ref.product_ref
             end
           end
         end

--- a/lib/cocoapods-spm/hooks/pre_integrate/update_settings.rb
+++ b/lib/cocoapods-spm/hooks/pre_integrate/update_settings.rb
@@ -47,12 +47,17 @@ module Pod
 
           # For packages to work in the main target
           perform_settings_update(
-            update_aggregate_targets: lambda do |target, _, _|
-              spm_deps = @spm_analyzer.spm_dependencies_by_target[target.to_s].to_a
-              flags = spm_deps.map { |d| "-l\"#{d.product}.o\"" }
-              { "OTHER_LDFLAGS" => flags }
+            update_targets: lambda do |target, _, _|
+              { "OTHER_LDFLAGS" => linker_flags_for(target) }
             end
           )
+        end
+
+        def linker_flags_for(target)
+          spm_deps = @spm_analyzer.spm_dependencies_by_target[target.to_s].to_a
+          flags = spm_deps.map { |d| "-l\"#{d.product}.o\"" }
+          flags << '-L"${PODS_CONFIGURATION_BUILD_DIR}"' unless flags.empty?
+          flags
         end
 
         def update_swift_include_paths


### PR DESCRIPTION
Link binaries according to settings in xcconfig instead.
This way, it's easier to later handle if the package is a static/dynamic library.