### PR TITLE
Link frameworks/libraries differently based on `:linkage` option

### DIFF
--- a/lib/cocoapods-spm/def/spm_dependency.rb
+++ b/lib/cocoapods-spm/def/spm_dependency.rb
@@ -14,6 +14,15 @@ module Pod
         @pkg = pkg
       end
 
+      def linkage
+        # TODO: How to detect the linkage of an SPM library?
+        @pkg.linkage.is_a?(Hash) ? @pkg.linkage[@product] : @pkg.linkage
+      end
+
+      def dynamic?
+        linkage == :dynamic
+      end
+
       def inspect
         "#<#{self.class} name=#{name} product=#{product} pkg=#{pkg}>"
       end

--- a/lib/cocoapods-spm/def/spm_package.rb
+++ b/lib/cocoapods-spm/def/spm_package.rb
@@ -4,7 +4,7 @@ require "cocoapods-spm/def/spm_dependency"
 module Pod
   module SPM
     class Package
-      attr_reader :name, :requirement, :url, :relative_path
+      attr_reader :name, :requirement, :url, :relative_path, :linkage
 
       def initialize(name, options = {})
         @name = name
@@ -12,6 +12,7 @@ module Pod
         @requirement = requirement_from(options)
         @url = options[:url]
         @relative_path = options[:relative_path]
+        @linkage = options[:linkage]
       end
 
       def inspect

--- a/lib/cocoapods-spm/hooks/pre_integrate/update_settings.rb
+++ b/lib/cocoapods-spm/hooks/pre_integrate/update_settings.rb
@@ -55,9 +55,11 @@ module Pod
 
         def linker_flags_for(target)
           spm_deps = @spm_analyzer.spm_dependencies_by_target[target.to_s].to_a
-          flags = spm_deps.map { |d| "-l\"#{d.product}.o\"" }
-          flags << '-L"${PODS_CONFIGURATION_BUILD_DIR}"' unless flags.empty?
-          flags
+          framework_flags = spm_deps.select(&:dynamic?).map { |d| "-framework \"#{d.product}\"" }
+          framework_flags << '-F"${PODS_CONFIGURATION_BUILD_DIR}/PackageFrameworks"' unless framework_flags.empty?
+          library_flags = spm_deps.reject(&:dynamic?).map { |d| "-l\"#{d.product}.o\"" }
+          library_flags << '-L"${PODS_CONFIGURATION_BUILD_DIR}"' unless library_flags.empty?
+          framework_flags + library_flags
         end
 
         def update_swift_include_paths


### PR DESCRIPTION
If not specified, the linkage is assumed to be `:static`.

* For `:dynamic`: Link against `Foo.framework` in `${PODS_CONFIGURATION_BUILD_DIR}/PackageFrameworks`
* For `:static`: Link against `Foo.o` in `${PODS_CONFIGURATION_BUILD_DIR}`

A package may have multiple products of multiple linkage types. For example, `Foo` is dynamic while `Bar` is static.
In that case, we specify the `:linkage` option as follows:

```rb
spm_pkg "FooBar", 
        ...
        :linkage => { "Foo" => :dynamic, "Bar" => :static }
```