### PR TITLE
FIX: Settings update went wrong in some edge cases

### DIFF
--- a/lib/cocoapods-spm/hooks/base.rb
+++ b/lib/cocoapods-spm/hooks/base.rb
@@ -62,6 +62,9 @@ module Pod
           hash = update.call(target, setting, config)
           setting.xcconfig.merge!(hash)
           setting.generate.merge!(hash)
+          Installer::Xcode::PodsProjectGenerator::TargetInstallerHelper.update_changed_file(
+            setting, target.xcconfig_path(config)
+          )
         end
 
         pod_targets.each do |target|

--- a/lib/cocoapods-spm/hooks/post_integrate/update_settings.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/update_settings.rb
@@ -32,7 +32,7 @@ module Pod
         end
 
         def update_other_swift_flags
-          return unless spm_config.macros
+          return if spm_config.all_macros.empty?
 
           # For prebuilt macros
           perform_settings_update(
@@ -43,7 +43,7 @@ module Pod
         end
 
         def update_linker_flags
-          return unless @spm_analyzer.spm_pkgs
+          return if @spm_analyzer.spm_pkgs.empty?
 
           # For packages to work in the main target
           perform_settings_update(
@@ -65,7 +65,7 @@ module Pod
         end
 
         def update_swift_include_paths
-          return unless @spm_analyzer.spm_pkgs
+          return if @spm_analyzer.spm_pkgs.empty?
 
           # For macro packages
           perform_settings_update(


### PR DESCRIPTION
Settings update went wrong in some edge cases.
Related issue: https://github.com/trinhngocthuyen/cocoapods-spm/issues/36

Updating xcconfig settings in the pre_integrate phase seems not reliable. Some irrelevant settings (such as HEADER_SEARCH_PATHS) may be messed up later.

Solution: Update the xcconfig in the post_integrate phase instead.