### PR TITLE
Redundant linker flags (in case of static frameworks)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,6 @@ ex.install:
 	cd examples && make install
 
 ex.test:
-	cd examples && make install test
+	cd examples && \
+		make install test LINKAGE=static && \
+		make install test LINKAGE=dynamic

--- a/examples/EX/SPMPackagePlayground.swift
+++ b/examples/EX/SPMPackagePlayground.swift
@@ -19,3 +19,9 @@ private struct Foo_SwiftUIX: View {
     ScrollView {}.dismissDisabled(false)
   }
 }
+
+struct Foo_SwiftyBeaver {
+  init() {
+    print(SwiftyBeaver.self)
+  }
+}

--- a/examples/Podfile
+++ b/examples/Podfile
@@ -1,5 +1,7 @@
 platform :ios, "16.0"
-use_frameworks! :linkage => (ENV["LINKAGE"] || :dynamic).to_sym
+linkage = (ENV["LINKAGE"] || :dynamic).to_sym
+use_frameworks! :linkage => linkage
+puts "Using linkage: #{linkage}"
 
 @checksum = "dummy-checksum-to-prevent-merge-conflicts"
 

--- a/lib/cocoapods-spm/hooks/post_integrate/update_settings.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/update_settings.rb
@@ -58,6 +58,8 @@ module Pod
         end
 
         def linker_flags_for(target)
+          return [] if !target.is_a?(Pod::AggregateTarget) && target.build_as_static?
+
           spm_deps = @spm_analyzer.spm_dependencies_by_target[target.to_s].to_a
           framework_flags = spm_deps.select(&:dynamic?).map { |d| "-framework \"#{d.product}\"" }
           library_flags = spm_deps.reject(&:dynamic?).map { |d| "-l\"#{d.product}.o\"" }


### PR DESCRIPTION
The linker flags of a target are only used when:
- This is a dynamic framework (ie. linking dependencies to the binary of the dynamic framework)
- This is an aggregate target (ex. Pods-EX). Note: Pods-EX is a static framework itself. However, we still need to update the linker flags in the xcconfig of Pods-EX. Those flags will be used for linking the main target (ie. EX) instead.