### PR TITLE
FIX: Corrupted json with `swift!` executable

### DIFF
--- a/lib/cocoapods-spm/macro/prebuilder.rb
+++ b/lib/cocoapods-spm/macro/prebuilder.rb
@@ -37,13 +37,9 @@ module Pod
         raise "Package.swift not exist in #{macro_downloaded_dir}" \
           unless (macro_downloaded_dir / "Package.swift").exist?
 
-        UI.message "Generating metadata at: #{metadata_path}" do
-          raw = Dir.chdir(macro_downloaded_dir) do
-            swift! ["package", "dump-package"]
-          end
-          metadata_path.write(raw)
-          @metadata = Metadata.from_s(raw)
-        end
+        raw = Dir.chdir(macro_downloaded_dir) { `swift package dump-package` }
+        metadata_path.write(raw)
+        @metadata = Metadata.from_s(raw)
       end
 
       def prebuild_macro_impl


### PR DESCRIPTION
`swift!`, or Executables, combines stdout and stderr together in the output https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/executable.rb#L70.

This leads to corrupted json when dumping package info with `swift package dump-package`.