### PR TITLE
FIX: Build failures when a package has headers path

### DIFF
--- a/lib/cocoapods-spm/metadata.rb
+++ b/lib/cocoapods-spm/metadata.rb
@@ -33,6 +33,11 @@ module Pod
         raw["products"]
       end
 
+      def product_names_of_target(name)
+        names = products.select { |h| h["targets"].include?(name) }.map { |h| h["name"] }
+        names.empty? ? [name] : names
+      end
+
       def targets_of_type(type)
         targets.select { |t| t["type"] == type }
       end

--- a/lib/cocoapods-spm/resolver/product.rb
+++ b/lib/cocoapods-spm/resolver/product.rb
@@ -2,12 +2,13 @@ module Pod
   module SPM
     class Resolver
       class Product
-        attr_reader :pkg, :name, :linkage
+        attr_reader :pkg, :name, :linkage, :headers_path
 
         def initialize(options = {})
           @pkg = options[:pkg]
           @name = options[:name]
           @linkage = options.fetch(:linkage, :static)
+          @headers_path = options[:headers_path]
         end
 
         def inspect


### PR DESCRIPTION
Fixes #39.

With C-family that defines public headers path, we need to explicitly specify the modulemap. Therefore, we need to:
- Add `-Xcc -fmodule-map-file=<path/to/modulemap>` to `OTHER_SWIFT_FLAGS` (for Swift target)
- Add `-fmodule-map-file=<path/to/modulemap>` to `OTHER_CFLAGS` (for C-family targets)

Note that with SPM packages, the generated modulemap files could be found in `${GENERATED_MODULEMAP_DIR}`.
