### PR TITLE
Do not append duplicated lines

### DIFF
--- a/lib/cocoapods-spm/hooks/post_integrate/6.update_embed_frameworks_script.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/6.update_embed_frameworks_script.rb
@@ -36,21 +36,28 @@ module Pod
           end
         end
 
+        def file_contains_line?(file_path, search_string)
+          File.foreach(file_path) do |line|
+            return true if line.include?(search_string)
+          end
+          false
+        end
+
         def update_embed_frameworks_script_files_path(target, config)
           input_paths = framework_paths_for(target)
-          output_paths = input_paths.map do |p|
+          output_paths = input_paths.sort.map do |p|
             "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{File.basename(p)}"
           end
           target.embed_frameworks_script_input_files_path(config).open("a+") do |file|
-            input_paths.each do |line|
-              unless file.include?(line)
+            input_paths.uniq.each do |line|
+              unless file_contains_line?(file.path, line)
                 file << "\n" << line
               end
             end
           end
           target.embed_frameworks_script_output_files_path(config).open("a+") do |file|
-            output_paths.each do |line|
-              unless file.include?(line)
+            output_paths.uniq.each do |line|
+              unless file_contains_line?(file.path, line)
                 file << "\n" << line
               end
             end

--- a/lib/cocoapods-spm/hooks/post_integrate/6.update_embed_frameworks_script.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/6.update_embed_frameworks_script.rb
@@ -41,11 +41,19 @@ module Pod
           output_paths = input_paths.map do |p|
             "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/#{File.basename(p)}"
           end
-          target.embed_frameworks_script_input_files_path(config).open("a") do |f|
-            input_paths.each { |p| f << "\n" << p }
+          target.embed_frameworks_script_input_files_path(config).open("a+") do |file|
+            input_paths.each do |line|
+              unless file.include?(line)
+                file << "\n" << line
+              end
+            end
           end
-          target.embed_frameworks_script_output_files_path(config).open("a") do |f|
-            output_paths.each { |p| f << "\n" << p }
+          target.embed_frameworks_script_output_files_path(config).open("a+") do |file|
+            output_paths.each do |line|
+              unless file.include?(line)
+                file << "\n" << line
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Hi @trinhngocthuyen 
First of all I want to thank you for this plugin. It saved me a lot of time and gave me a kick start with my Cocoapods to SPM migration.

When I was trying to add a dynamic SPM package as a dependency for some targets some lines where added to `*.xcfilelist` files every `pods install` run. This PR fixes that edge case. 