### PR TITLE
FEAT: Option to use default Xcode linking (ie. adding products to "Link Binary With Libraries")

### DIFF
--- a/examples/EX/SPMPackagePlayground.swift
+++ b/examples/EX/SPMPackagePlayground.swift
@@ -1,6 +1,7 @@
 import MacroCodableKit
 
 import DebugKit
+import GoogleMaps
 import OpenTelemetrySdk
 import Orcam
 import SnapKit
@@ -18,5 +19,6 @@ struct Foo {
     print(Constraint.self) // SnapKit
     print(DoubleCounterSdk.self) // OpenTelemetrySdk
     print(DebugKit.self) // DebugKit
+    print(GMSAddress.self) // GoogleMaps
   }
 }

--- a/examples/Podfile
+++ b/examples/Podfile
@@ -1,5 +1,5 @@
 platform :ios, "16.0"
-linkage = (ENV["LINKAGE"] || :dynamic).to_sym
+linkage = (ENV["LINKAGE"] || :static).to_sym
 use_frameworks! :linkage => linkage
 puts "Using linkage: #{linkage}"
 
@@ -39,6 +39,16 @@ target "EX" do
           :git => "https://github.com/open-telemetry/opentelemetry-swift.git",
           :branch => "main",
           :products => ["OpenTelemetrySdk"]
+  spm_pkg "GoogleMaps",
+          :git => "https://github.com/googlemaps/ios-maps-sdk.git",
+          :version => "8.4.0",
+          :products => ["GoogleMaps", "GoogleMapsBase", "GoogleMapsCore"],
+          :linking => {
+            # Prefer adding products to the "Link Binary With Libraries" section
+            :use_default_xcode_linking => true,
+            # Fix duplicate symbols with the -Objc flag: https://forums.developer.apple.com/forums/thread/739396
+            :linker_flags => ["-ld64"],
+          }
   spm_pkg "DebugKit", :path => "LocalPackages/debug-kit"
 end
 

--- a/lib/cocoapods-spm/def/spm_package.rb
+++ b/lib/cocoapods-spm/def/spm_package.rb
@@ -4,7 +4,7 @@ require "cocoapods-spm/def/spm_dependency"
 module Pod
   module SPM
     class Package
-      attr_reader :name, :requirement, :url, :relative_path
+      attr_reader :name, :requirement, :url, :relative_path, :linking_opts
 
       def initialize(name, options = {})
         @name = name
@@ -13,6 +13,7 @@ module Pod
         @linkage = nil
         @url = nil
         @requirement = nil
+        @linking_opts = {}
         parse_options(options)
       end
 
@@ -20,6 +21,7 @@ module Pod
         @url = options[:url] || options[:git]
         @relative_path = relative_path_from(options)
         @requirement = requirement_from(options)
+        @linking_opts = options[:linking] || {}
       end
 
       def slug
@@ -45,6 +47,14 @@ module Pod
 
       def local?
         @relative_path != nil
+      end
+
+      def use_default_xcode_linking?
+        @linking_opts.fetch(:use_default_xcode_linking, false)
+      end
+
+      def linker_flags
+        @linking_opts[:linker_flags] || []
       end
 
       def to_dependencies

--- a/lib/cocoapods-spm/hooks/post_integrate/1.add_spm_pkgs.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/1.add_spm_pkgs.rb
@@ -37,6 +37,7 @@ module Pod
               pkg_ref = spm_pkg_refs[dep.pkg.name]
               target_dep_ref = pkg_ref.create_target_dependency_ref(dep.product)
               target.dependencies << target_dep_ref
+              target.package_product_dependencies << target_dep_ref.product_ref if dep.pkg.use_default_xcode_linking?
             end
           end
         end

--- a/lib/cocoapods-spm/hooks/post_integrate/5.update_settings.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/5.update_settings.rb
@@ -71,9 +71,7 @@ module Pod
         def linker_flags_for(target)
           return [] if !target.is_a?(Pod::AggregateTarget) && target.build_as_static?
 
-          @spm_resolver.result.spm_products_for(target).map do |p|
-            p.linked_as_framework? ? "-framework \"#{p.name}\"" : "-l\"#{p.name}.o\""
-          end
+          @spm_resolver.result.linker_flags_for(target)
         end
 
         def update_swift_include_paths

--- a/lib/cocoapods-spm/resolver/product_dep_resolver.rb
+++ b/lib/cocoapods-spm/resolver/product_dep_resolver.rb
@@ -73,6 +73,8 @@ module Pod
 
         def resolve_product_deps
           @result.spm_dependencies_by_target.values.flatten.uniq(&:product).each do |dep|
+            next if dep.pkg.use_default_xcode_linking?
+
             verify_product_exists_in_pkg(dep.pkg.name, dep.product)
             product = create_product(dep.pkg.name, dep.product)
             recursive_products_of(product)

--- a/lib/cocoapods-spm/resolver/result.rb
+++ b/lib/cocoapods-spm/resolver/result.rb
@@ -35,7 +35,15 @@ module Pod
         end
 
         def spm_products_for(target)
-          spm_dependencies_for(target).flat_map { |d| @spm_products[d.product] }.uniq(&:name)
+          spm_dependencies_for(target).flat_map { |d| @spm_products[d.product].to_a }.uniq(&:name)
+        end
+
+        def linker_flags_for(target)
+          flags = spm_dependencies_for(target).flat_map { |d| d.pkg.linker_flags }
+          flags += spm_products_for(target).map do |p|
+            p.linked_as_framework? ? "-framework \"#{p.name}\"" : "-l\"#{p.name}.o\""
+          end
+          flags.uniq
         end
       end
     end


### PR DESCRIPTION
This PR introduces the option to fall back to the default Xcode linking, ie. adding products to the "Link Binary With Libraries" section.

Use this option by:
```rb
spm_pkg ...
        :linking => {
          :use_default_xcode_linking => true, # <-- HERE
        }
```

NOTE: We might get the "duplicate symbols" error when building the project.
This issue happens when having the `-ObjC` flag in the linking process.
A workaround to fix it is to specify the `-ld64` option (mentioned [here](https://forums.developer.apple.com/forums/thread/739396)).
This can be done by using the `:linker_flags` nested inside in `:linking` option.

```rb
spm_pkg ...
        :linking => {
          :use_default_xcode_linking => true, # <-- HERE
          :linker_flags => ["-ld64"], # <-- HERE
        }
```