### PR TITLE
FIX: Case insensitive and implicit modulemap

### DIFF
--- a/lib/cocoapods-spm/helpers/io.rb
+++ b/lib/cocoapods-spm/helpers/io.rb
@@ -1,6 +1,9 @@
 module Pod
   module IOUtils
     def self.symlink(src, dst)
+      # NOTE: File operations are case-insensitive (foo.json and Foo.json are identical)
+      return if File.identical?(src, dst)
+
       src = Pathname.new(src) unless src.is_a?(Pathname)
       dst = Pathname.new(dst) unless dst.is_a?(Pathname)
       dst.delete if dst.exist?


### PR DESCRIPTION
Fixes:
- Case insensitive, causing `Promises.json` and `promises.json` to be treated as identical. Related: https://github.com/trinhngocthuyen/cocoapods-spm/issues/87#issuecomment-2141028614
- Implicit modulemap (ex. FBLPromises). This modulemap is located under the headers path. When such a modulemap exists, don't specify the generated modulemap)