### PR TITLE
FEAT: Allow excluding dependency from top level (aggregate) target.

### DIFF
--- a/lib/cocoapods-spm/def/spm_package.rb
+++ b/lib/cocoapods-spm/def/spm_package.rb
@@ -55,6 +55,10 @@ module Pod
         @linking_opts.fetch(:use_default_xcode_linking, false)
       end
 
+      def should_exclude_from_target?(target_name)
+        @linking_opts.fetch(:exclude_from_targets, []).include?(target_name.delete_prefix('Pods-'))
+      end
+
       def linker_flags
         @linking_opts[:linker_flags] || []
       end


### PR DESCRIPTION
Let's say you have a target A that depends on pod B.
In B you want to use somePackage from SPM.
To do this you add the `spm_pkg => 'somePackage'` and so on to the target in the Podfile. an then spm_dependency 'somePackage' to B's podspec.
If pods are built as frameworks, this means that somePackage will be linked into pod B's framework and also to target A, even if target A does not need it. This needlessly increases A's binary size.

I added an option to not link somePackage to A.

It works, but it is of course possible I added this at the wrong level in code cause I don't fully know what I'm doing.