### PR TITLE
FIX: Determine uniqueness of packages by name.

### DIFF
--- a/lib/cocoapods-spm/resolver/target_dep_resolver.rb
+++ b/lib/cocoapods-spm/resolver/target_dep_resolver.rb
@@ -16,7 +16,7 @@ module Pod
         private
 
         def resolve_spm_pkgs
-          @result.spm_pkgs = @podfile.target_definition_list.flat_map(&:spm_pkgs).uniq
+          @result.spm_pkgs = @podfile.target_definition_list.flat_map(&:spm_pkgs).uniq(&:name)
         end
 
         def resolve_spm_dependencies_by_target

--- a/lib/cocoapods-spm/resolver/umbrella_package.rb
+++ b/lib/cocoapods-spm/resolver/umbrella_package.rb
@@ -5,7 +5,7 @@ module Pod
 
       def initialize(podfile)
         @podfile = podfile
-        @spm_pkgs = @podfile.target_definition_list.flat_map(&:spm_pkgs).uniq
+        @spm_pkgs = @podfile.target_definition_list.flat_map(&:spm_pkgs).uniq(&:name)
       end
 
       def prepare


### PR DESCRIPTION
I finally found what was causing the generation of a corrupt pods project "sometimes"!

If you have multiple targets in the Podfile that refer to the same SPM package, the `target_definition_list` in `target_dep_resolver.rb` contains this SPM package multiple times. They are all identical except for the UUID of the `XCRemoteSwiftPackageReference`. Because this UUID is unique for each, the `.uniq` filte keeps all of them. Then in `1.add_spm_pkgs.rb` these are all put in a hash that somehow can contain duplicate keys. From there on, when looking up in the hash, it's hit or miss whether it will consistently return the same `pkg_ref` or not. If it takes the wrong one, then the project becomes corrupt.

It is fixed by uniqueing (is this a word?) the `spm_pkgs` by name. This should be fine as long as all SPM packages references with the same name in the Podfile are identical. But I think this is an acceptable constraint because Cocoapods also does not support different references for the same Pod.

I also noticed that the same SPM package was added to the `.umbrella/Package.swift` multiple times for the same reason. That's also fixed, though SPM did not complain about it.