### PR TITLE
FIX: source packages checkouts dir when using custom BUILD_DIR (in flutter build)

### DIFF
--- a/lib/cocoapods-spm/hooks/post_integrate/5.update_settings.rb
+++ b/lib/cocoapods-spm/hooks/post_integrate/5.update_settings.rb
@@ -47,7 +47,7 @@ module Pod
           perform_settings_update(
             update_targets: lambda do |target, _, _|
               {
-                "SOURCE_PACKAGES_CHECKOUTS_DIR" => "${PODS_CONFIGURATION_BUILD_DIR}/../../../SourcePackages/checkouts",
+                "SOURCE_PACKAGES_CHECKOUTS_DIR" => "${BUILD_ROOT}/../../SourcePackages/checkouts",
                 "FRAMEWORK_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/PackageFrameworks\"",
                 "LIBRARY_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}\"",
                 "SWIFT_INCLUDE_PATHS" => "$(PODS_CONFIGURATION_BUILD_DIR)",


### PR DESCRIPTION
Fixes #122 

In Flutter, when running `flutter build ios`, it invokes an xcodebuild process with a custom BUILD_DIR.
When `BUILD_DIR` = `foo/bar`:
- `PODS_CONFIGURATION_BUILD_DIR` evaluates to `foo/bar/Debug-iphonesimulator` (for Debug & Simulator).
- Source packages checkouts dir still remains as usual: `~/Library/Developer/Xcode/DerivedData/Runner-blahblah/SourcePackages/checkouts`

So, in this case, `SOURCE_PACKAGES_CHECKOUTS_DIR` should be `${BUILD_ROOT}/../../SourcePackages/checkouts` instead. (`BUILD_ROOT` still refers to the one in DerivedData)
