### PR TITLE
FIX: Macro prebuild is not triggered in incremental installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/version_tmp/
 /tmp/
 /.local/
+.env
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/examples/Podfile
+++ b/examples/Podfile
@@ -18,7 +18,6 @@ config_compact_spec(
 )
 
 config_cocoapods_spm(
-  dont_prebuild_macros: true,
   default_macro_config: "debug"
 )
 

--- a/lib/cocoapods-spm/def/podfile.rb
+++ b/lib/cocoapods-spm/def/podfile.rb
@@ -7,7 +7,7 @@ module Pod
     attr_accessor :spm_resolver
 
     def config_cocoapods_spm(options)
-      SPM::Config.instance.dsl_config = options
+      SPM::Config.instance.dsl_config.merge!(options)
     end
 
     def macro_pods

--- a/lib/cocoapods-spm/macro/pod_installer.rb
+++ b/lib/cocoapods-spm/macro/pod_installer.rb
@@ -27,7 +27,7 @@ module Pod
       end
 
       def install_macro_pod!
-        fetcher.run
+        fetcher.run unless fetcher.metadata_path.exist?
         prebuilder.run
       end
     end

--- a/lib/cocoapods-spm/macro/prebuilder.rb
+++ b/lib/cocoapods-spm/macro/prebuilder.rb
@@ -23,10 +23,13 @@ module Pod
         config = spm_config.macro_config
         impl_module_name = metadata.macro_impl_name
         prebuilt_binary = macro_prebuilt_dir / "#{impl_module_name}-#{config}"
-        return if spm_config.dont_prebuild_macros_if_exist? && prebuilt_binary.exist?
+        if spm_config.dont_prebuild_macros_if_exist? && prebuilt_binary.exist?
+          return UI.message "Macro binary exists at #{prebuilt_binary} -> Skip prebuilding macro"
+        end
 
         UI.section "Building macro implementation: #{impl_module_name} (#{config})...".green do
           Dir.chdir(macro_downloaded_dir) do
+            swift! ["--version"]
             swift! ["build", "-c", config, "--product", impl_module_name]
           end
         end

--- a/lib/cocoapods-spm/main.rb
+++ b/lib/cocoapods-spm/main.rb
@@ -1,3 +1,4 @@
+require "pry" if ENV["COCOAPODS_IMPORT_PRY"] == "true"
 require "cocoapods-spm/compatibility/all"
 require "cocoapods-spm/helpers/io"
 require "cocoapods-spm/helpers/patch"

--- a/lib/cocoapods-spm/patch/installer.rb
+++ b/lib/cocoapods-spm/patch/installer.rb
@@ -34,6 +34,17 @@ module Pod
       run_spm_post_integrate_hooks
     end
 
+    patch_method :sandbox_state do
+      state = origin_sandbox_state
+      # NOTE: For macro pods, we force-trigger their source installers even in incremental installations.
+      # This is done by altering the `sandbox_state` & marking them as `added`
+      spm_config.all_macros.each do |name|
+        %i[unchanged changed deleted].each { |key| state.send(key).delete(name) }
+        state.added << (name)
+      end
+      state
+    end
+
     private
 
     def hook_options


### PR DESCRIPTION
Fix: Macro prebuild is not triggered in incremental installations (b/c sandbox_state detects macro pods as unchanged).
-> Force trigger source installation for macro pods

Related: #135