### PR TITLE
Add podspec dep local swift macro package case and fix the bundle exec pod install failure when .downloaded dir not exist

### DIFF
--- a/examples/LocalPods/CommonUI/CommonUI.podspec
+++ b/examples/LocalPods/CommonUI/CommonUI.podspec
@@ -3,4 +3,5 @@ Pod::CompactSpec.new do |s|
   s.spm_dependency "SwiftUIX/SwiftUIX"
   s.dependency "MacroCodableKit"
   s.dependency "Orcam"
+  s.dependency "Wizard"
 end

--- a/examples/LocalPods/CommonUI/Sources/CommonUI.swift
+++ b/examples/LocalPods/CommonUI/Sources/CommonUI.swift
@@ -7,10 +7,16 @@ private struct _ScrollView {
 }
 
 import Orcam
+import Wizard
 import MacroCodableKit
 
 @AllOfCodable // MacroCodableKit
 @Init // Orcam
 struct FooMacro {
   let x: Int
+
+  func check() {
+    let color = #uiColor(0xff0000)
+    print("color: \(color)")
+  }
 }

--- a/examples/Podfile.lock
+++ b/examples/Podfile.lock
@@ -2,6 +2,7 @@ PODS:
   - CommonUI (0.0.1):
     - MacroCodableKit
     - Orcam
+    - Wizard
   - Logger (0.0.1)
   - MacroCodableKit (0.0.1)
   - Orcam (0.0.1)
@@ -32,7 +33,7 @@ EXTERNAL SOURCES:
     :path: ".spm.pods/macros/Wizard"
 
 SPEC CHECKSUMS:
-  CommonUI: 90679c43fb06ad1f1de5ff4278ceadb3503a8340
+  CommonUI: 0df27321e720feead552ee844e42f344efe43d14
   Logger: 43a9cc3dc5f479042eb238d8680aaa0d6afd3ad2
   MacroCodableKit: 29a3a48508c673918521ef5db6f1485db2ca75d0
   Orcam: 288b7e3fc07e33706ceab2f226e4177e99847143

--- a/lib/cocoapods-spm/helpers/io.rb
+++ b/lib/cocoapods-spm/helpers/io.rb
@@ -6,6 +6,7 @@ module Pod
 
       src = Pathname.new(src) unless src.is_a?(Pathname)
       dst = Pathname.new(dst) unless dst.is_a?(Pathname)
+      dst.dirname.mkpath unless dst.dirname.exist?
       dst.delete if dst.exist?
       File.symlink(src.absolute? ? src : src.realpath, dst)
     end


### PR DESCRIPTION
when `.spm.pods/macros/.downloaded/` dir not exist,  execute `File.symlink(src.absolute? ? src : src.realpath, dst)` will failure with crash  as follow:
![image](https://github.com/user-attachments/assets/d2ba1157-6297-45bd-b0fd-854fccbc2e54)

dst dir should be created before create the symlink:
![image](https://github.com/user-attachments/assets/92382d82-aee4-468f-9ecc-6558fdcc1c15)

The examples project can work with no problem, because the other spm_pkg download triggered the `.downloaded` directory be created before the local macro pod symlink be created.